### PR TITLE
Fix two leaks, fix to use standard method naming conventions

### DIFF
--- a/VVOSC/FrameworkSrc/OSCManager.m
+++ b/VVOSC/FrameworkSrc/OSCManager.m
@@ -402,7 +402,9 @@
 #if IPHONE
 		tmpString = [NSString stringWithFormat:@"%@ %@ %d",[[UIDevice currentDevice] name],[self inPortLabelBase],index];
 #else
-		tmpString = [NSString stringWithFormat:@"%@ %@ %d",SCDynamicStoreCopyComputerName(NULL, NULL),[self inPortLabelBase],index];
+		CFStringRef computerName = SCDynamicStoreCopyComputerName(NULL, NULL);
+		tmpString = [NSString stringWithFormat:@"%@ %@ %d",computerName,[self inPortLabelBase],index];
+		CFRelease(computerName);
 #endif
 		//tmpString = [NSString stringWithFormat:@"%@ %d",[self inPortLabelBase],index];
 		

--- a/VVOSC/FrameworkSrc/OSCMessage.h
+++ b/VVOSC/FrameworkSrc/OSCMessage.h
@@ -47,7 +47,7 @@ According to the OSC spec, a message consists of an address path (where the mess
 - (id) initReplyForMessage:(OSCMessage *)m;
 - (id) initErrorForAddress:(NSString *)a;
 - (id) initErrorForMessage:(OSCMessage *)m;
-- (id) _fastInit:(NSString *)addr :(BOOL)addrHasWildcards :(OSCMessageType)mType :(OSCQueryType)qType :(unsigned int)qTxAddr :(unsigned short)qTxPort;
+- (id) initFast:(NSString *)addr :(BOOL)addrHasWildcards :(OSCMessageType)mType :(OSCQueryType)qType :(unsigned int)qTxAddr :(unsigned short)qTxPort;
 
 ///	Add the passed int to the message
 - (void) addInt:(int)n;

--- a/VVOSC/FrameworkSrc/OSCMessage.m
+++ b/VVOSC/FrameworkSrc/OSCMessage.m
@@ -264,7 +264,7 @@
 	*/
 	
 	//returnMe = [OSCMessage createWithAddress:address];
-	returnMe = [[OSCMessage alloc] _fastInit:address:hasWildcard:msgType:queryType:txAddr:txPort];
+	returnMe = [[OSCMessage alloc] initFast:address:hasWildcard:msgType:queryType:txAddr:txPort];
 	if (returnMe == nil)	{
 		NSLog(@"\t\terr: msg was nil %s",__func__);
 		return nil;
@@ -509,7 +509,7 @@
 	}
 	id			returnMe = nil;
 	NSString	*addrString = [a stringByDeletingLastAndAddingFirstSlash];
-	returnMe = [self _fastInit:
+	returnMe = [self initFast:
 		addrString:
 		((a==nil)?NO:[a containsOSCWildCard]):
 		OSCMessageTypeControl:
@@ -526,7 +526,7 @@
 	}
 	id			returnMe = nil;
 	NSString	*addrString = [a stringByDeletingLastAndAddingFirstSlash];
-	returnMe = [self _fastInit:
+	returnMe = [self initFast:
 		addrString:
 		((a==nil)?NO:[a containsOSCWildCard]):
 		OSCMessageTypeQuery:
@@ -543,7 +543,7 @@
 	}
 	id			returnMe = nil;
 	NSString	*addrString = [a stringByDeletingLastAndAddingFirstSlash];
-	returnMe = [self _fastInit:
+	returnMe = [self initFast:
 		nil:
 		NO:
 		OSCMessageTypeReply:
@@ -558,7 +558,7 @@
 	//NSLog(@"%s ... %@",__func__,m);
 	if (m==nil)
 		goto BAIL;
-	self = [self _fastInit:
+	self = [self initFast:
 		nil:
 		NO:
 		OSCMessageTypeReply:
@@ -591,7 +591,7 @@
 		return nil;
 	}
 	id			returnMe = nil;
-	returnMe = [self _fastInit:
+	returnMe = [self initFast:
 		a:
 		((a==nil)?NO:[a containsOSCWildCard]):
 		OSCMessageTypeError:
@@ -603,7 +603,7 @@
 - (id) initErrorForMessage:(OSCMessage *)m	{
 	if (m==nil)
 		goto BAIL;
-	self = [self _fastInit:
+	self = [self initFast:
 		nil:
 		NO:
 		OSCMessageTypeError:
@@ -628,7 +628,7 @@
 	return nil;
 }
 //	DOES NO CHECKING WHATSOEVER.  MEANT TO BE FAST, NOT SAFE.  USE OTHER CREATE/INIT METHODS.
-- (id) _fastInit:(NSString *)addr :(BOOL)addrHasWildcards :(OSCMessageType)mType :(OSCQueryType)qType :(unsigned int)qTxAddr :(unsigned short)qTxPort	{
+- (id) initFast:(NSString *)addr :(BOOL)addrHasWildcards :(OSCMessageType)mType :(OSCQueryType)qType :(unsigned int)qTxAddr :(unsigned short)qTxPort	{
 	if (self = [super init])	{
 		address = (addr==nil)?nil:[addr retain];
 		valueCount = 0;
@@ -649,7 +649,7 @@
 }
 - (id) copyWithZone:(NSZone *)z	{
 	//OSCMessage		*returnMe = [[OSCMessage allocWithZone:z] initWithAddress:address];
-	OSCMessage		*returnMe = [[OSCMessage allocWithZone:z] _fastInit:address:wildcardsInAddress:messageType:queryType:queryTXAddress:queryTXPort];
+	OSCMessage		*returnMe = [[OSCMessage allocWithZone:z] initFast:address:wildcardsInAddress:messageType:queryType:queryTXAddress:queryTXPort];
 	
 	if (valueCount == 1)
 		[returnMe addValue:value];
@@ -949,7 +949,10 @@
 	const char			*tmpChars = (tmpString==nil) ? nil : [tmpString UTF8String];
 	int					tmpCharsLength = (tmpChars==nil) ? 0 : (int)strlen(tmpChars);
 	
-	strncpy((char *)b, tmpChars, tmpCharsLength);
+	if (tmpCharsLength != 0)
+	{
+		strncpy((char *)b, tmpChars, tmpCharsLength);
+	}
 	typeWriteOffset += (tmpCharsLength + 1);
 	//	the actual type data location is rounded up to the nearest 4-byte segment
 	typeWriteOffset = ROUNDUP4(typeWriteOffset);

--- a/VVOSC/FrameworkSrc/OSCOutPort.m
+++ b/VVOSC/FrameworkSrc/OSCOutPort.m
@@ -115,10 +115,10 @@
 	if ((deleted) || (sock == -1) || (b == nil))
 		return;
 	
-	OSCPacket		*newPacket = [OSCPacket createWithContent:b];
+	OSCPacket		*packet = [OSCPacket createWithContent:b];
 	
-	if (newPacket != nil)
-		[self sendThisPacket:newPacket];
+	if (packet != nil)
+		[self sendThisPacket:packet];
 }
 - (void) sendThisMessage:(OSCMessage *)m	{
 	/*
@@ -165,6 +165,7 @@
 	
 	if (buff == NULL)	{
 		NSLog(@"\t\terr: packet's buffer was null");
+		[p release];
 		return;
 	}
 	//	send the packet's data to the destination

--- a/VVOSC/FrameworkSrc/OSCValue.m
+++ b/VVOSC/FrameworkSrc/OSCValue.m
@@ -413,7 +413,7 @@
 			break;
 		case OSCValTimeTag:
 			//returnMe = [[OSCValue allocWithZone:z] initWithTimeSeconds:*((long *)(value)) microSeconds:*((long *)(value+1))];
-			[[OSCValue allocWithZone:z] initWithTimeSeconds:(long)(*((long long *)value)>>32) microSeconds:(long)((*(long long *)value) & 0x00000000FFFFFFFF)];
+			returnMe = [[OSCValue allocWithZone:z] initWithTimeSeconds:(long)(*((long long *)value)>>32) microSeconds:(long)((*(long long *)value) & 0x00000000FFFFFFFF)];
 			break;
 		case OSCVal64Int:
 			returnMe = [[OSCValue allocWithZone:z] initWithLongLong:*(long long *)value];


### PR DESCRIPTION
This addresses potential leaks in VVOSC of varying gravity (none major) and a situation where strncpy() could be called with nothing to copy. It also renames a method and variable to follow Apple's naming conventions, resulting in more meaningful reports from static analysis.

The analyser indicates more issues remain - these were just the ones affecting me.
