### PR TITLE
specify pixel-format for global VVBufferPool

### DIFF
--- a/VVBufferPool/VVBufferPool.h
+++ b/VVBufferPool/VVBufferPool.h
@@ -101,6 +101,7 @@ Returns the max number of MSAA samples that can be taken with the GL renderer cu
 @param n The NSOpenGLContext you want the buffer pool to share.  This context should not be freed as long as VVBufferPool exists!
 */
 #if !TARGET_OS_IPHONE
++ (void) createGlobalVVBufferPoolWithSharedContext:(NSOpenGLContext *)n	pixelFormat:(NSOpenGLPixelFormat*)p;
 + (void) createGlobalVVBufferPoolWithSharedContext:(NSOpenGLContext *)n;
 #else	//	NOT !TARGET_OS_IPHONE
 + (void) createGlobalVVBufferPoolWithSharegroup:(EAGLSharegroup *)n;

--- a/VVBufferPool/VVBufferPool.m
+++ b/VVBufferPool/VVBufferPool.m
@@ -92,13 +92,16 @@ VVMStopwatch		*_bufferTimestampMaker = nil;
 	}
 }
 #if !TARGET_OS_IPHONE
-+ (void) createGlobalVVBufferPoolWithSharedContext:(NSOpenGLContext *)n	{
++ (void) createGlobalVVBufferPoolWithSharedContext:(NSOpenGLContext *)n	pixelFormat:(NSOpenGLPixelFormat*)p {
 	VVRELEASE(_globalVVBufferPool);
 	if (n==nil)
 		return;
-	_globalVVBufferPool = [[VVBufferPool alloc] initWithSharedContext:n pixelFormat:[GLScene defaultPixelFormat] sized:VVMAKESIZE(1,1)];
+	_globalVVBufferPool = [[VVBufferPool alloc] initWithSharedContext:n pixelFormat:p sized:VVMAKESIZE(1,1)];
 	if (_globalVVBufferCopier == nil)
 		[VVBufferCopier createGlobalVVBufferCopierWithSharedContext:n];
+}
++ (void) createGlobalVVBufferPoolWithSharedContext:(NSOpenGLContext *)n	{
+    return [self createGlobalVVBufferPoolWithSharedContext:n pixelFormat:[GLScene defaultPixelFormat]];
 }
 #else	//	NOT !TARGET_OS_IPHONE
 + (void) createGlobalVVBufferPoolWithSharegroup:(EAGLSharegroup *)n	{


### PR DESCRIPTION
Hello.

We needed to specify the pixel-format to support ISF in Millumin.
Indeed, if not, it would failed to init global VVBufferPool, at least for GPUs Intel Iris and AMD FirePro D300. I mean : 
[VVBufferPool createGlobalVVBufferPoolWithSharedContext:sharedContext] would raise "err: context was nil -[GLScene _renderPrep]"

Let me know if you have a question.
Philippe